### PR TITLE
feat: Event Stack - Priority-based visual stacking for overlapping events

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,47 @@ function MyCalendar() {
 | `useCalendarState` | Calendar navigation and date state |
 | `useTimeRange` | Calculate visible time range |
 | `useEventLayout` | Position events with overlap handling |
+| `useEventStack` | **NEW** Priority-based event stacking |
 | `useEventsMap` | Group events by date |
 | `useTimeAxis` | Generate time axis labels |
 | `useGridLines` | Generate grid lines |
 | `useCurrentTimeIndicator` | Track "now" line position |
+
+## Event Stacking
+
+Stack overlapping events based on priority:
+
+```tsx
+import { useEventStack, StackedEventGroup } from '@plain-calendar/react'
+
+function MyTimeline({ events }) {
+  const { stackedEvents, maxStackDepth, hasStacks } = useEventStack(events, {
+    offsetPx: 6,       // Visual offset per stack level
+    maxStack: 5,       // Maximum stack depth
+    getPriority: (e) => e.data?.priority ?? 999,
+  })
+
+  return (
+    <div className="timeline">
+      {stackedEvents.map((se) => (
+        <div
+          key={se.event.id}
+          style={{
+            marginLeft: se.stackOffset,
+            marginTop: se.stackOffset,
+            zIndex: se.stackLayer,
+          }}
+        >
+          {se.event.title}
+          {se.stackSize > 1 && ` (+${se.stackSize - 1} more)`}
+        </div>
+      ))}
+    </div>
+  )
+}
+```
+
+Lower priority numbers = base layer. Higher priority events stack on top with visual offsets.
 
 ## Components
 
@@ -83,6 +120,7 @@ function MyCalendar() {
 | `WeekView` | 7-day week grid |
 | `Calendar` | Month grid view |
 | `EventBlock` | Positioned event display |
+| `StackedEventGroup` | **NEW** Container for stacked events |
 
 All components are **headless** - they provide structure and logic, you provide the styling via render props.
 
@@ -106,8 +144,9 @@ pnpm build
 **Active Development** - Core functionality complete, working on polish and publishing.
 
 - ✅ Core utilities and types
-- ✅ React hooks (9 hooks)
-- ✅ React components (4 components)
+- ✅ React hooks (10 hooks)
+- ✅ React components (5 components)
+- ✅ Event stacking algorithm
 - ✅ Demo site deployed
 - 🔲 npm publishing
 - 🔲 E2E tests

--- a/memory-bank/02-active/currentWork.md
+++ b/memory-bank/02-active/currentWork.md
@@ -1,9 +1,10 @@
 # Current Work - Plain Calendar
 
-**Status**: Phases 1-3 Complete, Demo Deployed
-**Last Updated**: December 1, 2025
+**Status**: Event Stack Feature Complete, Ready for PR
+**Last Updated**: December 6, 2025
 **GitHub**: https://github.com/alosec/plain-calendar
 **Live Demo**: https://plain-cal-demo.pages.dev
+**Branch**: feature/event-stack
 
 ## Project Summary
 
@@ -17,10 +18,11 @@ plain-calendar is a headless React calendar component library - the "TanStack Ta
 - Core TypeScript types
 - timeUtils and dateUtils (52 tests)
 
-**Phase 2: Hooks (9 hooks)**
+**Phase 2: Hooks (10 hooks)**
 - useCalendarState - Navigation and date state
 - useTimeRange - Visible time range calculation
 - useEventLayout - Event positioning with overlap handling
+- useEventStack - **NEW** Priority-based event stacking
 - useEventsMap - Events grouped by date
 - useTimeAxis - Time axis labels (12h/24h)
 - useGridLines - Grid line generation
@@ -28,55 +30,66 @@ plain-calendar is a headless React calendar component library - the "TanStack Ta
 - useDateCache - Date object caching (LRU)
 - useTimeProportionalLayout - Time to Y-position
 
-**Phase 3: Components (4 components)**
+**Phase 3: Components (5 components)**
 - EventBlock - Headless event display
 - Timeline - Day timeline view
 - WeekView - 7-day week layout
 - Calendar - Month grid view
+- StackedEventGroup - **NEW** Container for stacked events
+
+**Phase 4: Event Stacking (NEW)**
+- stackUtils.ts - Core stacking algorithm
+  - eventsOverlap() - Detect overlapping events
+  - groupOverlappingEvents() - Cluster overlapping events
+  - calculateStackLayers() - Assign layers by priority
+  - stackEvents() - Main API function
+- StackedEvent type with stackLayer, stackOffset, parent, children
+- 22 tests for stacking algorithm
+- 8 tests for useEventStack hook
 
 **Demo Site**
 - Deployed to Cloudflare Pages
 - Day/Week/Month views with navigation
-- Realistic mock schedule data
-- Screenshot captured for README
+- Screenshot: https://screenshots-5wx.pages.dev/plain-cal-demo-before.png
 
 ### Test Coverage
-- 71 passing tests (52 core + 19 react)
+- 101 passing tests (74 core + 27 react)
 
 ### Build Outputs
-- @plain-calendar/core: 8.4kb (gzip: 2.2kb)
-- @plain-calendar/react: 71.5kb (gzip: 15.5kb)
+- @plain-calendar/core: 11.4kb (gzip: 3.0kb) - includes stack utils
+- @plain-calendar/react: 73kb (gzip: 15.9kb)
 
-## Remaining Work (Phase 4)
+## Current Branch
 
-### High Priority
-- npm publishing configuration (calendar-mxn)
-- README documentation polish (calendar-9vh) ✅ Done
+`feature/event-stack` is ready for PR with:
+- Core stacking algorithm
+- React hook and component
+- Full test coverage
+- Updated documentation
 
-### Medium Priority
-- GitHub Actions CI pipeline (calendar-1h1)
-- Astro demo app (calendar-2kk)
+## Related Issues
 
-### Lower Priority
-- Playwright E2E tests (calendar-3g1, calendar-7hg, etc.)
-- CONTRIBUTING.md (calendar-075)
+- GitHub: https://github.com/alosec/plain-calendar/issues/1
+- Linear: ABG-169
+
+## Next Steps
+
+1. Create PR for event-stack branch
+2. Publish to npm (need package.json config)
+3. Update pedicalendar to use published package
 
 ## Quick Commands
 
 ```bash
 # Development
-cd ~/code/plain-calendar
-pnpm test           # Run all tests (71 passing)
+cd ~/code/plain-calendar-event-stack
+pnpm test           # Run all tests (101 passing)
 pnpm build          # Build all packages
 
 # Demo deployment
 cd ~/code/plain-cal-demo
 npm run build
 wrangler pages deploy dist/ --project-name=plain-cal-demo
-
-# Issue tracking
-cd ~/code/plain-calendar
-bd ready            # See next tasks
 ```
 
 ## Key Decisions Made
@@ -86,3 +99,4 @@ bd ready            # See next tasks
 3. **No external deps**: Only React as peer dependency
 4. **TypeScript only**: No JavaScript distribution
 5. **Extracted patterns**: Based on production PediCalendar code
+6. **Priority-based stacking**: Lower priority number = base layer (matches venue priority)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,4 @@
 export * from './types';
 export * from './timeUtils';
 export * from './dateUtils';
+export * from './stackUtils';

--- a/packages/core/src/stackUtils.test.ts
+++ b/packages/core/src/stackUtils.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for stackUtils - Event stacking algorithm
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  eventsOverlap,
+  findOverlappingEvents,
+  groupOverlappingEvents,
+  calculateStackLayers,
+  stackEvents,
+  getBaseLayerEvents,
+  getMaxStackDepth,
+} from './stackUtils';
+import type { CalendarEvent } from './types';
+
+// Helper to create test events
+function createEvent(
+  id: string,
+  startHour: number,
+  endHour: number,
+  priority: number = 999
+): CalendarEvent {
+  const baseDate = new Date('2025-01-15');
+  return {
+    id,
+    title: `Event ${id}`,
+    start: new Date(baseDate.getFullYear(), baseDate.getMonth(), baseDate.getDate(), startHour, 0),
+    end: new Date(baseDate.getFullYear(), baseDate.getMonth(), baseDate.getDate(), endHour, 0),
+    data: { priority },
+  };
+}
+
+describe('eventsOverlap', () => {
+  it('returns true for overlapping events', () => {
+    const a = createEvent('a', 10, 12);
+    const b = createEvent('b', 11, 13);
+    expect(eventsOverlap(a, b)).toBe(true);
+    expect(eventsOverlap(b, a)).toBe(true);
+  });
+
+  it('returns true when one event contains another', () => {
+    const outer = createEvent('outer', 10, 14);
+    const inner = createEvent('inner', 11, 13);
+    expect(eventsOverlap(outer, inner)).toBe(true);
+    expect(eventsOverlap(inner, outer)).toBe(true);
+  });
+
+  it('returns false for non-overlapping events', () => {
+    const a = createEvent('a', 10, 11);
+    const b = createEvent('b', 12, 13);
+    expect(eventsOverlap(a, b)).toBe(false);
+  });
+
+  it('returns false for adjacent events (touching but not overlapping)', () => {
+    const a = createEvent('a', 10, 11);
+    const b = createEvent('b', 11, 12);
+    expect(eventsOverlap(a, b)).toBe(false);
+  });
+});
+
+describe('findOverlappingEvents', () => {
+  it('finds all events that overlap with target', () => {
+    const target = createEvent('target', 10, 14);
+    const overlap1 = createEvent('o1', 11, 12);
+    const overlap2 = createEvent('o2', 13, 15);
+    const noOverlap = createEvent('no', 15, 16);
+    
+    const all = [target, overlap1, overlap2, noOverlap];
+    const result = findOverlappingEvents(target, all);
+    
+    expect(result).toHaveLength(2);
+    expect(result.map(e => e.id)).toContain('o1');
+    expect(result.map(e => e.id)).toContain('o2');
+    expect(result.map(e => e.id)).not.toContain('target');
+    expect(result.map(e => e.id)).not.toContain('no');
+  });
+
+  it('returns empty array when no overlaps', () => {
+    const target = createEvent('target', 10, 11);
+    const other = createEvent('other', 12, 13);
+    
+    const result = findOverlappingEvents(target, [target, other]);
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('groupOverlappingEvents', () => {
+  it('groups overlapping events together', () => {
+    const a = createEvent('a', 10, 12);
+    const b = createEvent('b', 11, 13);
+    const c = createEvent('c', 15, 16);
+    
+    const groups = groupOverlappingEvents([a, b, c]);
+    
+    expect(groups).toHaveLength(2);
+    // First group has overlapping events
+    const group1Ids = groups[0].map(e => e.id).sort();
+    expect(group1Ids).toEqual(['a', 'b']);
+    // Second group is standalone
+    expect(groups[1].map(e => e.id)).toEqual(['c']);
+  });
+
+  it('handles chain overlaps (a overlaps b, b overlaps c, but a does not overlap c)', () => {
+    const a = createEvent('a', 10, 12);
+    const b = createEvent('b', 11, 14);
+    const c = createEvent('c', 13, 15);
+    
+    const groups = groupOverlappingEvents([a, b, c]);
+    
+    // All should be in same group due to chain
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toHaveLength(3);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(groupOverlappingEvents([])).toEqual([]);
+  });
+
+  it('handles single event', () => {
+    const a = createEvent('a', 10, 11);
+    const groups = groupOverlappingEvents([a]);
+    expect(groups).toEqual([[a]]);
+  });
+});
+
+describe('calculateStackLayers', () => {
+  it('assigns layer 0 to single event', () => {
+    const a = createEvent('a', 10, 11);
+    const result = calculateStackLayers([a]);
+    
+    expect(result).toHaveLength(1);
+    expect(result[0].stackLayer).toBe(0);
+    expect(result[0].stackOffset).toBe(0);
+    expect(result[0].parent).toBeNull();
+  });
+
+  it('stacks events by priority (lower priority number = base layer)', () => {
+    const high = createEvent('high', 10, 14, 1);
+    const medium = createEvent('medium', 11, 13, 5);
+    const low = createEvent('low', 11, 12, 10);
+    
+    const result = calculateStackLayers([low, high, medium]);
+    
+    const byId = new Map(result.map(r => [r.event.id, r]));
+    
+    expect(byId.get('high')!.stackLayer).toBe(0);
+    expect(byId.get('medium')!.stackLayer).toBe(1);
+    expect(byId.get('low')!.stackLayer).toBe(2);
+  });
+
+  it('applies correct offset per layer', () => {
+    const a = createEvent('a', 10, 14, 1);
+    const b = createEvent('b', 11, 13, 2);
+    const c = createEvent('c', 11, 12, 3);
+    
+    const result = calculateStackLayers([a, b, c], { offsetPx: 10 });
+    
+    const byId = new Map(result.map(r => [r.event.id, r]));
+    
+    expect(byId.get('a')!.stackOffset).toBe(0);
+    expect(byId.get('b')!.stackOffset).toBe(10);
+    expect(byId.get('c')!.stackOffset).toBe(20);
+  });
+
+  it('respects maxStack limit', () => {
+    const events = [
+      createEvent('a', 10, 14, 1),
+      createEvent('b', 11, 13, 2),
+      createEvent('c', 11, 12, 3),
+      createEvent('d', 11, 12, 4),
+      createEvent('e', 11, 12, 5),
+    ];
+    
+    const result = calculateStackLayers(events, { maxStack: 3 });
+    
+    // Last two should be clamped to layer 2 (maxStack - 1)
+    const layers = result.map(r => r.stackLayer);
+    expect(Math.max(...layers)).toBe(2);
+  });
+
+  it('sets parent relationships correctly', () => {
+    const parent = createEvent('parent', 10, 14, 1);
+    const child = createEvent('child', 11, 13, 5);
+    
+    const result = calculateStackLayers([parent, child]);
+    
+    const byId = new Map(result.map(r => [r.event.id, r]));
+    
+    expect(byId.get('parent')!.parent).toBeNull();
+    expect(byId.get('child')!.parent).toBe(byId.get('parent'));
+    expect(byId.get('parent')!.children).toContain(byId.get('child'));
+  });
+
+  it('sets stackSize correctly', () => {
+    const a = createEvent('a', 10, 14, 1);
+    const b = createEvent('b', 11, 13, 2);
+    
+    const result = calculateStackLayers([a, b]);
+    
+    expect(result[0].stackSize).toBe(2);
+    expect(result[1].stackSize).toBe(2);
+  });
+});
+
+describe('stackEvents', () => {
+  it('stacks all events across multiple groups', () => {
+    // Group 1: overlapping
+    const a = createEvent('a', 10, 12, 1);
+    const b = createEvent('b', 11, 13, 2);
+    // Group 2: standalone
+    const c = createEvent('c', 15, 16, 1);
+    
+    const result = stackEvents([a, b, c]);
+    
+    expect(result).toHaveLength(3);
+    
+    const byId = new Map(result.map(r => [r.event.id, r]));
+    
+    // Group 1 is stacked
+    expect(byId.get('a')!.stackLayer).toBe(0);
+    expect(byId.get('b')!.stackLayer).toBe(1);
+    // Group 2 is standalone (layer 0)
+    expect(byId.get('c')!.stackLayer).toBe(0);
+  });
+
+  it('handles empty input', () => {
+    expect(stackEvents([])).toEqual([]);
+  });
+});
+
+describe('getBaseLayerEvents', () => {
+  it('returns only layer 0 events', () => {
+    const a = createEvent('a', 10, 14, 1);
+    const b = createEvent('b', 11, 13, 2);
+    const c = createEvent('c', 15, 16, 1);
+    
+    const stacked = stackEvents([a, b, c]);
+    const base = getBaseLayerEvents(stacked);
+    
+    expect(base).toHaveLength(2);
+    expect(base.map(s => s.event.id).sort()).toEqual(['a', 'c']);
+  });
+});
+
+describe('getMaxStackDepth', () => {
+  it('returns maximum stack layer', () => {
+    const events = [
+      createEvent('a', 10, 14, 1),
+      createEvent('b', 11, 13, 2),
+      createEvent('c', 11, 12, 3),
+    ];
+    
+    const stacked = stackEvents(events);
+    expect(getMaxStackDepth(stacked)).toBe(2);
+  });
+
+  it('returns 0 for single event', () => {
+    const stacked = stackEvents([createEvent('a', 10, 11)]);
+    expect(getMaxStackDepth(stacked)).toBe(0);
+  });
+
+  it('returns 0 for empty input', () => {
+    expect(getMaxStackDepth([])).toBe(0);
+  });
+});

--- a/packages/core/src/stackUtils.ts
+++ b/packages/core/src/stackUtils.ts
@@ -1,0 +1,176 @@
+/**
+ * stackUtils - Event stacking algorithm for priority-based visual layout
+ * 
+ * Stacks overlapping events based on priority, creating a nested visual hierarchy
+ * where higher priority events contain lower priority events.
+ */
+
+import type { CalendarEvent, StackedEvent, StackOptions } from './types';
+
+/**
+ * Check if two events overlap in time
+ */
+export function eventsOverlap(a: CalendarEvent, b: CalendarEvent): boolean {
+  return a.start < b.end && a.end > b.start;
+}
+
+/**
+ * Get default priority from event (lower number = higher priority)
+ */
+export function getDefaultPriority(event: CalendarEvent): number {
+  const data = event.data as { priority?: number } | undefined;
+  return data?.priority ?? 999;
+}
+
+/**
+ * Find all events that overlap with the given event
+ */
+export function findOverlappingEvents<T extends CalendarEvent>(
+  event: T,
+  events: T[]
+): T[] {
+  return events.filter(other => other.id !== event.id && eventsOverlap(event, other));
+}
+
+/**
+ * Group events into overlapping clusters
+ */
+export function groupOverlappingEvents<T extends CalendarEvent>(
+  events: T[]
+): T[][] {
+  if (events.length === 0) return [];
+  
+  const groups: T[][] = [];
+  const assigned = new Set<string>();
+  
+  // Sort by start time for consistent grouping
+  const sorted = [...events].sort((a, b) => a.start.getTime() - b.start.getTime());
+  
+  for (const event of sorted) {
+    if (assigned.has(event.id)) continue;
+    
+    // Start a new group with this event
+    const group: T[] = [event];
+    assigned.add(event.id);
+    
+    // Find all events that overlap with any event in the group
+    let i = 0;
+    while (i < group.length) {
+      const current = group[i];
+      for (const other of sorted) {
+        if (!assigned.has(other.id) && eventsOverlap(current, other)) {
+          group.push(other);
+          assigned.add(other.id);
+        }
+      }
+      i++;
+    }
+    
+    groups.push(group);
+  }
+  
+  return groups;
+}
+
+/**
+ * Calculate stack layers for a group of overlapping events
+ */
+export function calculateStackLayers<T extends CalendarEvent>(
+  events: T[],
+  options: StackOptions = {}
+): StackedEvent<T>[] {
+  const {
+    offsetPx = 8,
+    maxStack = 5,
+    getPriority = getDefaultPriority,
+  } = options;
+  
+  if (events.length === 0) return [];
+  if (events.length === 1) {
+    return [{
+      event: events[0],
+      stackLayer: 0,
+      stackOffset: 0,
+      stackSize: 1,
+      children: [],
+      parent: null,
+    }];
+  }
+  
+  // Sort by priority (lower number = higher priority = base layer)
+  const sorted = [...events].sort((a, b) => {
+    const prioDiff = getPriority(a) - getPriority(b);
+    if (prioDiff !== 0) return prioDiff;
+    // Tie-breaker: earlier start time
+    return a.start.getTime() - b.start.getTime();
+  });
+  
+  // Build stacked events
+  const stacked: StackedEvent<T>[] = [];
+  const stackedById = new Map<string, StackedEvent<T>>();
+  
+  for (let i = 0; i < sorted.length; i++) {
+    const event = sorted[i];
+    const layer = Math.min(i, maxStack - 1);
+    
+    const stackedEvent: StackedEvent<T> = {
+      event,
+      stackLayer: layer,
+      stackOffset: layer * offsetPx,
+      stackSize: sorted.length,
+      children: [],
+      parent: null,
+    };
+    
+    // Find parent (first higher-priority event that overlaps)
+    for (let j = i - 1; j >= 0; j--) {
+      const potentialParent = stackedById.get(sorted[j].id);
+      if (potentialParent && eventsOverlap(event, sorted[j])) {
+        stackedEvent.parent = potentialParent;
+        potentialParent.children.push(stackedEvent);
+        break;
+      }
+    }
+    
+    stacked.push(stackedEvent);
+    stackedById.set(event.id, stackedEvent);
+  }
+  
+  return stacked;
+}
+
+/**
+ * Main function: Calculate stacked positions for all events
+ */
+export function stackEvents<T extends CalendarEvent>(
+  events: T[],
+  options: StackOptions = {}
+): StackedEvent<T>[] {
+  const groups = groupOverlappingEvents(events);
+  const allStacked: StackedEvent<T>[] = [];
+  
+  for (const group of groups) {
+    const stacked = calculateStackLayers(group, options);
+    allStacked.push(...stacked);
+  }
+  
+  return allStacked;
+}
+
+/**
+ * Get only base layer events (for rendering primary events)
+ */
+export function getBaseLayerEvents<T extends CalendarEvent>(
+  stackedEvents: StackedEvent<T>[]
+): StackedEvent<T>[] {
+  return stackedEvents.filter(se => se.stackLayer === 0);
+}
+
+/**
+ * Get maximum stack depth across all events
+ */
+export function getMaxStackDepth<T extends CalendarEvent>(
+  stackedEvents: StackedEvent<T>[]
+): number {
+  return Math.max(0, ...stackedEvents.map(se => se.stackLayer));
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -120,6 +120,42 @@ export interface UseEventLayoutReturn<T extends CalendarEvent = CalendarEvent> {
   hasOverlaps: boolean;
 }
 
+// ============================================================================
+// Event Stack Types
+// ============================================================================
+
+/** Event with stacking information for priority-based visual layout */
+export interface StackedEvent<T extends CalendarEvent = CalendarEvent> {
+  event: T;
+  /** Stack depth (0 = base/highest priority, higher = more nested) */
+  stackLayer: number;
+  /** Pixel offset for visual nesting */
+  stackOffset: number;
+  /** Total events in this stack group */
+  stackSize: number;
+  /** Events stacked on top of this one */
+  children: StackedEvent<T>[];
+  /** Parent event this is stacked within (null for base layer) */
+  parent: StackedEvent<T> | null;
+}
+
+/** Options for event stacking algorithm */
+export interface StackOptions {
+  /** Pixels to offset each stack level (default: 8) */
+  offsetPx?: number;
+  /** Maximum stack depth to display (default: 5) */
+  maxStack?: number;
+  /** Priority accessor function (default: event.data?.priority or 999) */
+  getPriority?: (event: CalendarEvent) => number;
+}
+
+/** useEventStack return type */
+export interface UseEventStackReturn<T extends CalendarEvent = CalendarEvent> {
+  stackedEvents: StackedEvent<T>[];
+  maxStackDepth: number;
+  hasStacks: boolean;
+}
+
 /** useCurrentTimeIndicator return type */
 export interface UseCurrentTimeIndicatorReturn {
   position: number; // percentage

--- a/packages/react/src/components/StackedEventGroup.tsx
+++ b/packages/react/src/components/StackedEventGroup.tsx
@@ -1,0 +1,82 @@
+/**
+ * StackedEventGroup - Headless container for rendering stacked events
+ */
+
+import React from 'react';
+import type { CalendarEvent, StackedEvent } from '@plain-calendar/core';
+
+export interface StackedEventGroupProps<T extends CalendarEvent = CalendarEvent> {
+  /** Stacked events to render (from useEventStack) */
+  stackedEvents: StackedEvent<T>[];
+  /** Render function for each stacked event */
+  renderEvent: (stackedEvent: StackedEvent<T>, index: number) => React.ReactNode;
+  /** Container element type (default: 'div') */
+  as?: keyof JSX.IntrinsicElements;
+  /** Container class name */
+  className?: string;
+  /** Container style */
+  style?: React.CSSProperties;
+  /** Whether to render only base layer events (default: false) */
+  baseLayerOnly?: boolean;
+}
+
+/**
+ * Get inline styles for a stacked event based on its layer
+ */
+export function getStackedEventStyle(
+  stackedEvent: StackedEvent,
+  baseStyle: React.CSSProperties = {}
+): React.CSSProperties {
+  return {
+    ...baseStyle,
+    // Apply offset for nested events
+    marginLeft: stackedEvent.stackOffset,
+    marginTop: stackedEvent.stackOffset,
+    // Reduce size slightly for nested events
+    width: stackedEvent.stackLayer > 0 
+      ? `calc(100% - ${stackedEvent.stackOffset * 2}px)` 
+      : undefined,
+    // Higher layers get higher z-index
+    zIndex: (baseStyle.zIndex as number ?? 0) + stackedEvent.stackLayer,
+  };
+}
+
+/**
+ * Headless component for rendering stacked events.
+ * 
+ * @example
+ * ```tsx
+ * <StackedEventGroup
+ *   stackedEvents={stackedEvents}
+ *   renderEvent={(se) => (
+ *     <div
+ *       key={se.event.id}
+ *       style={getStackedEventStyle(se, { position: 'absolute' })}
+ *     >
+ *       {se.event.title}
+ *       {se.stackLayer > 0 && <span>(nested)</span>}
+ *     </div>
+ *   )}
+ * />
+ * ```
+ */
+export function StackedEventGroup<T extends CalendarEvent = CalendarEvent>({
+  stackedEvents,
+  renderEvent,
+  as: Component = 'div',
+  className,
+  style,
+  baseLayerOnly = false,
+}: StackedEventGroupProps<T>): React.ReactElement {
+  const eventsToRender = baseLayerOnly
+    ? stackedEvents.filter(se => se.stackLayer === 0)
+    : stackedEvents;
+
+  return (
+    <Component className={className} style={style}>
+      {eventsToRender.map((stackedEvent, index) => renderEvent(stackedEvent, index))}
+    </Component>
+  );
+}
+
+export default StackedEventGroup;

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -10,3 +10,6 @@ export type { WeekViewProps } from './WeekView';
 
 export { Calendar } from './Calendar';
 export type { CalendarProps } from './Calendar';
+
+export { StackedEventGroup, getStackedEventStyle } from './StackedEventGroup';
+export type { StackedEventGroupProps } from './StackedEventGroup';

--- a/packages/react/src/hooks/useEventStack.test.ts
+++ b/packages/react/src/hooks/useEventStack.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for useEventStack hook
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useEventStack } from './useEventStack';
+import type { CalendarEvent } from '@plain-calendar/core';
+
+// Helper to create test events
+function createEvent(
+  id: string,
+  startHour: number,
+  endHour: number,
+  priority: number = 999
+): CalendarEvent {
+  const baseDate = new Date('2025-01-15');
+  return {
+    id,
+    title: `Event ${id}`,
+    start: new Date(baseDate.getFullYear(), baseDate.getMonth(), baseDate.getDate(), startHour, 0),
+    end: new Date(baseDate.getFullYear(), baseDate.getMonth(), baseDate.getDate(), endHour, 0),
+    data: { priority },
+  };
+}
+
+describe('useEventStack', () => {
+  it('returns empty array for no events', () => {
+    const { result } = renderHook(() => useEventStack([]));
+    
+    expect(result.current.stackedEvents).toEqual([]);
+    expect(result.current.maxStackDepth).toBe(0);
+    expect(result.current.hasStacks).toBe(false);
+  });
+
+  it('returns single event without stacking', () => {
+    const events = [createEvent('a', 10, 12)];
+    const { result } = renderHook(() => useEventStack(events));
+    
+    expect(result.current.stackedEvents).toHaveLength(1);
+    expect(result.current.stackedEvents[0].stackLayer).toBe(0);
+    expect(result.current.hasStacks).toBe(false);
+  });
+
+  it('stacks overlapping events by priority', () => {
+    const events = [
+      createEvent('high', 10, 14, 1),
+      createEvent('medium', 11, 13, 5),
+      createEvent('low', 11, 12, 10),
+    ];
+    
+    const { result } = renderHook(() => useEventStack(events));
+    
+    expect(result.current.stackedEvents).toHaveLength(3);
+    expect(result.current.hasStacks).toBe(true);
+    
+    const byId = new Map(
+      result.current.stackedEvents.map(se => [se.event.id, se])
+    );
+    
+    expect(byId.get('high')!.stackLayer).toBe(0);
+    expect(byId.get('medium')!.stackLayer).toBe(1);
+    expect(byId.get('low')!.stackLayer).toBe(2);
+  });
+
+  it('calculates correct maxStackDepth', () => {
+    const events = [
+      createEvent('a', 10, 14, 1),
+      createEvent('b', 11, 13, 2),
+      createEvent('c', 11, 12, 3),
+      createEvent('d', 11, 12, 4),
+    ];
+    
+    const { result } = renderHook(() => useEventStack(events));
+    
+    expect(result.current.maxStackDepth).toBe(3);
+  });
+
+  it('respects offsetPx option', () => {
+    const events = [
+      createEvent('a', 10, 14, 1),
+      createEvent('b', 11, 13, 2),
+    ];
+    
+    const { result } = renderHook(() => 
+      useEventStack(events, { offsetPx: 12 })
+    );
+    
+    const byId = new Map(
+      result.current.stackedEvents.map(se => [se.event.id, se])
+    );
+    
+    expect(byId.get('a')!.stackOffset).toBe(0);
+    expect(byId.get('b')!.stackOffset).toBe(12);
+  });
+
+  it('respects maxStack option', () => {
+    const events = [
+      createEvent('a', 10, 14, 1),
+      createEvent('b', 11, 13, 2),
+      createEvent('c', 11, 12, 3),
+      createEvent('d', 11, 12, 4),
+      createEvent('e', 11, 12, 5),
+    ];
+    
+    const { result } = renderHook(() => 
+      useEventStack(events, { maxStack: 3 })
+    );
+    
+    // All layers should be clamped to maxStack - 1 = 2
+    const maxLayer = Math.max(
+      ...result.current.stackedEvents.map(se => se.stackLayer)
+    );
+    expect(maxLayer).toBe(2);
+  });
+
+  it('uses custom getPriority function', () => {
+    const events = [
+      { ...createEvent('a', 10, 14), data: { importance: 'low' } },
+      { ...createEvent('b', 11, 13), data: { importance: 'high' } },
+    ];
+    
+    const getPriority = (e: CalendarEvent) => {
+      const data = e.data as { importance?: string };
+      return data?.importance === 'high' ? 1 : 10;
+    };
+    
+    const { result } = renderHook(() => 
+      useEventStack(events, { getPriority })
+    );
+    
+    const byId = new Map(
+      result.current.stackedEvents.map(se => [se.event.id, se])
+    );
+    
+    // 'b' has high importance so should be layer 0
+    expect(byId.get('b')!.stackLayer).toBe(0);
+    expect(byId.get('a')!.stackLayer).toBe(1);
+  });
+
+  it('handles non-overlapping events separately', () => {
+    const events = [
+      createEvent('morning', 8, 10, 1),
+      createEvent('evening', 18, 20, 1),
+    ];
+    
+    const { result } = renderHook(() => useEventStack(events));
+    
+    // Both should be layer 0 since they don't overlap
+    expect(result.current.stackedEvents.every(se => se.stackLayer === 0)).toBe(true);
+    expect(result.current.hasStacks).toBe(false);
+  });
+});

--- a/packages/react/src/hooks/useEventStack.ts
+++ b/packages/react/src/hooks/useEventStack.ts
@@ -1,0 +1,53 @@
+/**
+ * useEventStack - React hook for priority-based event stacking
+ */
+
+import { useMemo } from 'react';
+import type {
+  CalendarEvent,
+  StackOptions,
+  UseEventStackReturn,
+} from '@plain-calendar/core';
+import {
+  stackEvents,
+  getMaxStackDepth,
+} from '@plain-calendar/core';
+
+export interface UseEventStackOptions extends StackOptions {}
+
+/**
+ * Hook for calculating stacked event positions based on priority.
+ * 
+ * @example
+ * ```tsx
+ * const { stackedEvents, maxStackDepth } = useEventStack(events, {
+ *   offsetPx: 8,
+ *   maxStack: 5,
+ *   getPriority: (e) => e.data?.priority ?? 999,
+ * });
+ * ```
+ */
+export function useEventStack<T extends CalendarEvent = CalendarEvent>(
+  events: T[],
+  options: UseEventStackOptions = {}
+): UseEventStackReturn<T> {
+  const stackedEvents = useMemo(() => {
+    return stackEvents(events, options);
+  }, [events, options.offsetPx, options.maxStack, options.getPriority]);
+
+  const maxStackDepth = useMemo(() => {
+    return getMaxStackDepth(stackedEvents);
+  }, [stackedEvents]);
+
+  const hasStacks = useMemo(() => {
+    return stackedEvents.some(se => se.stackSize > 1);
+  }, [stackedEvents]);
+
+  return {
+    stackedEvents,
+    maxStackDepth,
+    hasStacks,
+  };
+}
+
+export default useEventStack;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -24,6 +24,9 @@ export { useDateCache } from './hooks/useDateCache';
 
 export { useTimeProportionalLayout } from './hooks/useTimeProportionalLayout';
 
+export { useEventStack } from './hooks/useEventStack';
+export type { UseEventStackOptions } from './hooks/useEventStack';
+
 // Components
 export * from './components';
 


### PR DESCRIPTION
## Summary

Adds Event Stack feature for priority-based visual stacking of overlapping events. Higher priority events form the base layer, with lower priority events stacked on top with visual offsets.

## Changes

### Core (packages/core)
- **stackUtils.ts** - Pure functions for stacking algorithm
  - `eventsOverlap()` - Detect overlapping events
  - `groupOverlappingEvents()` - Cluster overlapping events
  - `calculateStackLayers()` - Assign stack layers by priority
  - `stackEvents()` - Main API function
  - `getBaseLayerEvents()` - Filter to base layer
  - `getMaxStackDepth()` - Get max nesting depth

- **types.ts** - New types
  - `StackedEvent<T>` - Event with stacking info (stackLayer, stackOffset, parent, children)
  - `StackOptions` - Configuration options
  - `UseEventStackReturn<T>` - Hook return type

### React (packages/react)
- **useEventStack** hook - Memoized stacking calculation
- **StackedEventGroup** component - Headless container for rendering

### Documentation
- Updated README with stacking usage example

## Visual Concept

```
┌─────────────────────────────┐
│ High Priority Event (P1)    │
│  ┌──────────────────────┐   │
│  │ Medium Priority (P2)  │   │
│  │  ┌─────────────────┐ │   │
│  │  │ Low Priority P3  │ │   │
│  │  └─────────────────┘ │   │
│  └──────────────────────┘   │
└─────────────────────────────┘
```

## Testing

- 22 new tests for core stacking algorithm
- 8 new tests for useEventStack hook
- All 101 tests passing

## Usage

```tsx
import { useEventStack } from '@plain-calendar/react'

const { stackedEvents, maxStackDepth, hasStacks } = useEventStack(events, {
  offsetPx: 6,
  maxStack: 5,
  getPriority: (e) => e.data?.priority ?? 999,
})
```

## Related

- Closes #1
- Linear: ABG-169
- Used by: pedicalendar_v2#7

## Screenshots

Before (current demo):
![plain-cal-demo](https://screenshots-5wx.pages.dev/plain-cal-demo-before.png)
